### PR TITLE
Implement `getName()` to `ConnectionInterface::class`.

### DIFF
--- a/src/ConnectionPDO.php
+++ b/src/ConnectionPDO.php
@@ -55,6 +55,11 @@ final class ConnectionPDO extends AbstractConnectionPDO
         return parent::getLastInsertID($sequenceName);
     }
 
+    public function getName(): string
+    {
+        return $this->getDriver()->getName();
+    }
+
     /**
      * @throws Exception|InvalidConfigException
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
