### PR TITLE
Remove `getCacheKey()` to `ConnectionInterface::class`.

### DIFF
--- a/src/Schema.php
+++ b/src/Schema.php
@@ -11,12 +11,12 @@ use Yiisoft\Db\Constraint\Constraint;
 use Yiisoft\Db\Constraint\DefaultValueConstraint;
 use Yiisoft\Db\Constraint\ForeignKeyConstraint;
 use Yiisoft\Db\Constraint\IndexConstraint;
+use Yiisoft\Db\Driver\PDO\PdoAbstractSchema;
 use Yiisoft\Db\Exception\Exception;
 use Yiisoft\Db\Exception\InvalidConfigException;
 use Yiisoft\Db\Exception\NotSupportedException;
 use Yiisoft\Db\Expression\Expression;
 use Yiisoft\Db\Helper\ArrayHelper;
-use Yiisoft\Db\Schema\AbstractSchema;
 use Yiisoft\Db\Schema\Builder\ColumnInterface;
 use Yiisoft\Db\Schema\ColumnSchemaInterface;
 use Yiisoft\Db\Schema\TableSchemaInterface;
@@ -77,7 +77,7 @@ use function substr;
  *   foreign_column_name: string,
  * }
  */
-final class Schema extends AbstractSchema
+final class Schema extends PdoAbstractSchema
 {
     /**
      * @var array The mapping from physical column types (keys) to abstract column types (values).
@@ -1065,7 +1065,7 @@ final class Schema extends AbstractSchema
      */
     protected function getCacheKey(string $name): array
     {
-        return array_merge([self::class], $this->db->getCacheKey(), [$this->getRawTableName($name)]);
+        return array_merge([self::class], $this->generateCacheKey(), [$this->getRawTableName($name)]);
     }
 
     /**
@@ -1077,6 +1077,6 @@ final class Schema extends AbstractSchema
      */
     protected function getCacheTag(): string
     {
-        return md5(serialize(array_merge([self::class], $this->db->getCacheKey())));
+        return md5(serialize(array_merge([self::class], $this->generateCacheKey())));
     }
 }

--- a/tests/SchemaTest.php
+++ b/tests/SchemaTest.php
@@ -8,6 +8,7 @@ use JsonException;
 use Throwable;
 use Yiisoft\Db\Command\CommandInterface;
 use Yiisoft\Db\Connection\ConnectionInterface;
+use Yiisoft\Db\Driver\PDO\ConnectionPDOInterface;
 use Yiisoft\Db\Exception\Exception;
 use Yiisoft\Db\Exception\InvalidConfigException;
 use Yiisoft\Db\Exception\NotSupportedException;
@@ -407,7 +408,7 @@ final class SchemaTest extends CommonSchemaTest
 
         $commandMock = $this->createMock(CommandInterface::class);
         $commandMock->method('queryAll')->willReturn([]);
-        $mockDb = $this->createMock(ConnectionInterface::class);
+        $mockDb = $this->createMock(ConnectionPDOInterface::class);
         $mockDb->method('getQuoter')->willReturn($db->getQuoter());
         $mockDb
             ->expects(self::atLeastOnce())
@@ -512,5 +513,16 @@ final class SchemaTest extends CommonSchemaTest
         $schema = $db->getSchema()->getTableSchema('schema2.custom_type_test_table');
         $this->assertEquals('my_type', $schema->getColumn('test_type')->getDbType());
         $this->assertEquals('schema2.my_type2', $schema->getColumn('test_type2')->getDbType());
+    }
+
+    public function testNotConnectionPDO(): void
+    {
+        $db = $this->createMock(ConnectionInterface::class);
+        $schema = new Schema($db, DbHelper::getSchemaCache(), 'system');
+
+        $this->expectException(NotSupportedException::class);
+        $this->expectExceptionMessage('Only PDO connections are supported.');
+
+        $schema->refreshTableSchema('customer');
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Issue | https://github.com/yiisoft/db/pull/650
