### PR TITLE
Update `ArrayParser` class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Chg #288: Typecast refactoring (@Tigrov)
 - Chg #291: Update phpTypecast for bool type (@Tigrov)
 - Enh #294: Refactoring of `Schema::normalizeDefaultValue()` method (@Tigrov)
+- Bug #296: Prevent posible issues with array default values `('{one,two}'::text[])::varchar[]`, remove `ArrayParser::parseString()` (@Tigrov)
 
 ## 1.0.0 April 12, 2023
 

--- a/src/ArrayParser.php
+++ b/src/ArrayParser.php
@@ -40,7 +40,8 @@ final class ArrayParser
             $result[] = match ($value[$i]) {
                 '{' => $this->parseArray($value, $i),
                 ',', '}' => null,
-                default => $this->parseString($value, $i),
+                '"' => $this->parseQuotedString($value, $i),
+                default => $this->parseUnquotedString($value, $i),
             };
 
             if ($value[$i] === '}') {
@@ -48,19 +49,6 @@ final class ArrayParser
                 return $result;
             }
         }
-    }
-
-    /**
-     * Parses PostgreSQL encoded string.
-     *
-     * @param string $value String to parse.
-     * @param int $i Parse starting position.
-     */
-    private function parseString(string $value, int &$i): string|null
-    {
-        return $value[$i] === '"'
-            ? $this->parseQuotedString($value, $i)
-            : $this->parseUnquotedString($value, $i);
     }
 
     /**

--- a/src/ArrayParser.php
+++ b/src/ArrayParser.php
@@ -18,7 +18,7 @@ final class ArrayParser
      */
     public function parse(string|null $value): array|null
     {
-        return $value !== null
+        return $value !== null && $value[0] === '{'
             ? $this->parseArray($value)
             : null;
     }

--- a/tests/ArrayParserTest.php
+++ b/tests/ArrayParserTest.php
@@ -30,5 +30,8 @@ final class ArrayParserTest extends TestCase
             [0 => '[",","null",true,"false","f"]'],
             $arrayParse->parse('{"[\",\",\"null\",true,\"false\",\"f\"]"}')
         );
+
+        // Similar cases can be in default values
+        $this->assertSame(null, $arrayParse->parse("'{one,two}'::text[]"));
     }
 }


### PR DESCRIPTION
* Prevent posible issues with array default values `('{one,two}'::text[])::varchar[]`
* Remove `parseString()` method

| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | -
