### PR TITLE
Fix retrieve sequence name from default value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Enh #300: Refactor `ArrayExpressionBuilder` (@Tigrov)
 - Enh #302: Refactor `ColumnSchema` (@Tigrov)
 - Bug #302: Fix incorrect convert string value for BIT type (@Tigrov)
+- Bug #309: Fix retrieving sequence name from default value (@Tigrov)
 
 ## 1.1.0 July 24, 2023
 

--- a/src/Schema.php
+++ b/src/Schema.php
@@ -800,7 +800,7 @@ final class Schema extends AbstractPdoSchema
 
         if (
             $defaultValue !== null
-            && preg_match("/^nextval\('([^']+)'(?:::regclass)?\)$/", $defaultValue, $matches) === 1
+            && preg_match("/^nextval\('([^']+)/", $defaultValue, $matches) === 1
         ) {
             $column->sequenceName($matches[1]);
         } elseif ($info['sequence_name'] !== null) {

--- a/src/Schema.php
+++ b/src/Schema.php
@@ -800,13 +800,9 @@ final class Schema extends AbstractPdoSchema
 
         if (
             $defaultValue !== null
-            && preg_match("/nextval\\('\"?\\w+\"?\.?\"?\\w+\"?'(::regclass)?\\)/", $defaultValue) === 1
+            && preg_match("/^nextval\('([^']+)'(?:::regclass)?\)$/", $defaultValue, $matches) === 1
         ) {
-            $column->sequenceName(preg_replace(
-                ['/nextval/', '/::/', '/regclass/', '/\'\)/', '/\(\'/'],
-                '',
-                $defaultValue
-            ));
+            $column->sequenceName($matches[1]);
         } elseif ($info['sequence_name'] !== null) {
             $column->sequenceName($this->resolveTableName($info['sequence_name'])->getFullName());
         }

--- a/tests/SchemaTest.php
+++ b/tests/SchemaTest.php
@@ -291,14 +291,14 @@ final class SchemaTest extends CommonSchemaTest
         $sequenceName = $tableSchema->getSequenceName();
         $command->setSql(
             <<<SQL
-            ALTER TABLE "item" ALTER COLUMN "id" SET DEFAULT nextval('item_id_seq_2')
+            ALTER TABLE "item" ALTER COLUMN "id" SET DEFAULT nextval('nextval_item_id_seq_2')
             SQL,
         )->execute();
         $schema->refreshTableSchema('item');
         $tableSchema = $schema->getTableSchema('item');
 
         $this->assertNotNull($tableSchema);
-        $this->assertEquals('item_id_seq_2', $tableSchema->getSequenceName());
+        $this->assertEquals('nextval_item_id_seq_2', $tableSchema->getSequenceName());
 
         $command->setSql(
             <<<SQL

--- a/tests/Support/Fixture/pgsql.sql
+++ b/tests/Support/Fixture/pgsql.sql
@@ -1,7 +1,7 @@
 DROP TABLE IF EXISTS "composite_fk" CASCADE;
 DROP TABLE IF EXISTS "order_item" CASCADE;
 DROP TABLE IF EXISTS "item" CASCADE;
-DROP SEQUENCE IF EXISTS "item_id_seq_2" CASCADE;
+DROP SEQUENCE IF EXISTS "nextval_item_id_seq_2" CASCADE;
 DROP TABLE IF EXISTS "order_item_with_null_fk" CASCADE;
 DROP TABLE IF EXISTS "order" CASCADE;
 DROP TABLE IF EXISTS "order_with_null_fk" CASCADE;
@@ -88,7 +88,7 @@ CREATE TABLE "item" (
   name varchar(128) NOT NULL,
   category_id integer NOT NULL references "category"(id) on UPDATE CASCADE on DELETE CASCADE
 );
-CREATE SEQUENCE "item_id_seq_2";
+CREATE SEQUENCE "nextval_item_id_seq_2";
 
 CREATE TABLE "order" (
   id serial not null primary key,


### PR DESCRIPTION
Strings `nextval` or `regclass` can be in sequence name

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | -