### PR TITLE
`$expression->getType()` returns database type but not an abstract type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Enh #302: Refactor `ColumnSchema` (@Tigrov)
 - Bug #302: Fix incorrect convert string value for BIT type (@Tigrov)
 - Bug #309: Fix retrieving sequence name from default value (@Tigrov)
+- Chg #319: Remove use of abstract type `SchemaInterface::TYPE_JSONB` (@Tigrov)
 
 ## 1.1.0 July 24, 2023
 

--- a/src/Builder/ArrayExpressionBuilder.php
+++ b/src/Builder/ArrayExpressionBuilder.php
@@ -14,7 +14,6 @@ use Yiisoft\Db\Expression\ExpressionInterface;
 use Yiisoft\Db\Expression\JsonExpression;
 use Yiisoft\Db\Query\QueryInterface;
 use Yiisoft\Db\QueryBuilder\QueryBuilderInterface;
-use Yiisoft\Db\Schema\SchemaInterface;
 
 use function implode;
 use function in_array;

--- a/src/Builder/ArrayExpressionBuilder.php
+++ b/src/Builder/ArrayExpressionBuilder.php
@@ -157,7 +157,7 @@ final class ArrayExpressionBuilder implements ExpressionBuilderInterface
             return $value;
         }
 
-        if (in_array($expression->getType(), [SchemaInterface::TYPE_JSON, SchemaInterface::TYPE_JSONB], true)) {
+        if (in_array($expression->getType(), ['json', 'jsonb'], true)) {
             return new JsonExpression($value);
         }
 


### PR DESCRIPTION
**Related PR:** yiisoft/db#765

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️/❌
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | -
