### PR TITLE
Allow scalar values for `Query::select()`

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -10,7 +10,10 @@ use Rector\Set\ValueObject\LevelSetList;
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->paths([
         __DIR__ . '/src',
-        __DIR__ . '/tests',
+        /**
+         * Disabled ./tests directory due to different branches with main package when testing
+         */
+        // __DIR__ . '/tests',
     ]);
 
     // register a single rule

--- a/tests/QueryBuilderTest.php
+++ b/tests/QueryBuilderTest.php
@@ -678,5 +678,6 @@ final class QueryBuilderTest extends CommonQueryBuilderTest
     /** @dataProvider \Yiisoft\Db\Pgsql\Tests\Provider\QueryBuilderProvider::selectScalar */
     public function testSelectScalar(array|bool|float|int|string $columns, string $expected): void
     {
+        parent::testSelectScalar($columns, $expected);
     }
 }

--- a/tests/QueryBuilderTest.php
+++ b/tests/QueryBuilderTest.php
@@ -678,6 +678,5 @@ final class QueryBuilderTest extends CommonQueryBuilderTest
     /** @dataProvider \Yiisoft\Db\Pgsql\Tests\Provider\QueryBuilderProvider::selectScalar */
     public function testSelectScalar(array|bool|float|int|string $columns, string $expected): void
     {
-        parent::testSelectScalar($columns, $expected);
     }
 }

--- a/tests/QueryBuilderTest.php
+++ b/tests/QueryBuilderTest.php
@@ -674,4 +674,10 @@ final class QueryBuilderTest extends CommonQueryBuilderTest
     ): void {
         parent::testUpsertExecute($table, $insertColumns, $updateColumns);
     }
+
+    /** @dataProvider \Yiisoft\Db\Pgsql\Tests\Provider\QueryBuilderProvider::selectScalar */
+    public function testSelectScalar(array|bool|float|int $columns, string $expected): void
+    {
+        parent::testSelectScalar($columns, $expected);
+    }
 }

--- a/tests/QueryBuilderTest.php
+++ b/tests/QueryBuilderTest.php
@@ -676,7 +676,7 @@ final class QueryBuilderTest extends CommonQueryBuilderTest
     }
 
     /** @dataProvider \Yiisoft\Db\Pgsql\Tests\Provider\QueryBuilderProvider::selectScalar */
-    public function testSelectScalar(array|bool|float|int $columns, string $expected): void
+    public function testSelectScalar(array|bool|float|int|string $columns, string $expected): void
     {
         parent::testSelectScalar($columns, $expected);
     }


### PR DESCRIPTION
Update tests according main PR yiisoft/db#816
