### PR TITLE
Remove `getCacheKey()` and `getCacheTag()` from `Schema`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 - Chg #390: Remove `yiisoft/json` dependency (@Tigrov)
 - Enh #393: Refactor according changes in `db` package (@Tigrov)
 - New #391: Add `caseSensitive` option to like condition (@vjik)
+- Enh #396: Remove `getCacheKey()` and `getCacheTag()` methods from `Schema` class (@Tigrov)
 
 ## 1.3.0 March 21, 2024
 

--- a/src/Schema.php
+++ b/src/Schema.php
@@ -906,28 +906,4 @@ final class Schema extends AbstractPdoSchema
 
         return $result[$returnType];
     }
-
-    /**
-     * Returns the cache key for the specified table name.
-     *
-     * @param string $name The table name.
-     *
-     * @return array The cache key.
-     */
-    protected function getCacheKey(string $name): array
-    {
-        return [self::class, ...$this->generateCacheKey(), $this->db->getQuoter()->getRawTableName($name)];
-    }
-
-    /**
-     * Returns the cache tag name.
-     *
-     * This allows {@see refresh()} to invalidate all cached table schemas.
-     *
-     * @return string The cache tag name.
-     */
-    protected function getCacheTag(): string
-    {
-        return md5(serialize([self::class, ...$this->generateCacheKey()]));
-    }
 }


### PR DESCRIPTION
### Related PR
- https://github.com/yiisoft/db/pull/943

| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | 