### PR TITLE
Call `DbArrayHelper::arrange()` instead of `DbArrayHelper::index()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
 - Enh #393: Refactor according changes in `db` package (@Tigrov)
 - New #391: Add `caseSensitive` option to like condition (@vjik)
 - Enh #396: Remove `getCacheKey()` and `getCacheTag()` methods from `Schema` class (@Tigrov)
+- Enh #403: Use `DbArrayHelper::arrange()` instead of `DbArrayHelper::index()` method (@Tigrov)
 
 ## 1.3.0 March 21, 2024
 

--- a/src/Schema.php
+++ b/src/Schema.php
@@ -303,7 +303,7 @@ final class Schema extends AbstractPdoSchema
 
         /** @psalm-var array[] $indexes */
         $indexes = array_map(array_change_key_case(...), $indexes);
-        $indexes = DbArrayHelper::index($indexes, null, ['name']);
+        $indexes = DbArrayHelper::arrange($indexes, ['name']);
         $result = [];
 
         /**
@@ -843,7 +843,7 @@ final class Schema extends AbstractPdoSchema
 
         /** @psalm-var array[][] $constraints */
         $constraints = array_map(array_change_key_case(...), $constraints);
-        $constraints = DbArrayHelper::index($constraints, null, ['type', 'name']);
+        $constraints = DbArrayHelper::arrange($constraints, ['type', 'name']);
 
         $result = [
             self::PRIMARY_KEY => null,


### PR DESCRIPTION
Related PR
- https://github.com/yiisoft/db/pull/954

| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️/❌
| Breaks BC?    | ✔️/❌
| Fixed issues  | 
