### PR TITLE
Rename `getLastInsertID()` method in `ConnectionInterface` to `getLastInsertId()`

### DIFF
--- a/src/Connection.php
+++ b/src/Connection.php
@@ -51,13 +51,13 @@ final class Connection extends AbstractPdoConnection
         return $this->columnFactory ??= new ColumnFactory();
     }
 
-    public function getLastInsertID(?string $sequenceName = null): string
+    public function getLastInsertId(?string $sequenceName = null): string
     {
         if ($sequenceName === null) {
             throw new InvalidArgumentException('PostgreSQL not support lastInsertId without sequence name.');
         }
 
-        return parent::getLastInsertID($sequenceName);
+        return parent::getLastInsertId($sequenceName);
     }
 
     public function getQueryBuilder(): QueryBuilderInterface

--- a/tests/PdoConnectionTest.php
+++ b/tests/PdoConnectionTest.php
@@ -41,7 +41,7 @@ final class PdoConnectionTest extends CommonPdoConnectionTest
             ]
         )->execute();
 
-        $this->assertSame('4', $db->getLastInsertID('public.customer_id_seq'));
+        $this->assertSame('4', $db->getLastInsertId('public.customer_id_seq'));
 
         $db->close();
     }
@@ -63,7 +63,7 @@ final class PdoConnectionTest extends CommonPdoConnectionTest
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('PostgreSQL not support lastInsertId without sequence name.');
 
-        $db->getLastInsertID();
+        $db->getLastInsertId();
 
         $db->close();
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌

Related to https://github.com/yiisoft/db/pull/965