### PR TITLE
Fix #495: Add missed parameters for building expressions in `ArrayOverlapsBuilder` and `JsonOverlapsBuilder` classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Bug #484: Fix building range-type column definitions (@Tigrov)
 - Enh #489: Clarify return type of `phpTypecast()` methods for range columns (@Tigrov)
 - New #492: Add `getBounds()` method to range values (@Tigrov)
-- Enh #495: Minor fixes (@Tigrov)
+- Bug #495: Add missed parameters for building expressions in `ArrayOverlapsBuilder` and `JsonOverlapsBuilder` classes (@Tigrov)
 
 ## 2.0.1 February 07, 2026
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Bug #484: Fix building range-type column definitions (@Tigrov)
 - Enh #489: Clarify return type of `phpTypecast()` methods for range columns (@Tigrov)
 - New #492: Add `getBounds()` method to range values (@Tigrov)
+- Enh #495: Minor fixes (@Tigrov)
 
 ## 2.0.1 February 07, 2026
 

--- a/src/Builder/ArrayOverlapsBuilder.php
+++ b/src/Builder/ArrayOverlapsBuilder.php
@@ -32,7 +32,7 @@ final class ArrayOverlapsBuilder implements ExpressionBuilderInterface
     public function build(ExpressionInterface $expression, array &$params = []): string
     {
         $column = $expression->column instanceof ExpressionInterface
-            ? $this->queryBuilder->buildExpression($expression->column)
+            ? $this->queryBuilder->buildExpression($expression->column, $params)
             : $this->queryBuilder->getQuoter()->quoteColumnName($expression->column);
         $values = $expression->values;
 

--- a/src/Builder/JsonOverlapsBuilder.php
+++ b/src/Builder/JsonOverlapsBuilder.php
@@ -32,7 +32,7 @@ final class JsonOverlapsBuilder implements ExpressionBuilderInterface
     public function build(ExpressionInterface $expression, array &$params = []): string
     {
         $column = $expression->column instanceof ExpressionInterface
-            ? $this->queryBuilder->buildExpression($expression->column)
+            ? $this->queryBuilder->buildExpression($expression->column, $params)
             : $this->queryBuilder->getQuoter()->quoteColumnName($expression->column);
         $values = $expression->values;
 

--- a/src/Column/ColumnFactory.php
+++ b/src/Column/ColumnFactory.php
@@ -179,7 +179,7 @@ final class ColumnFactory extends AbstractColumnFactory
     protected function normalizeNotNullDefaultValue(string $defaultValue, ColumnInterface $column): mixed
     {
         /** @var string $value */
-        $value = preg_replace("/::[^:']+$/", '$1', $defaultValue);
+        $value = preg_replace("/::[^:']+$/", '', $defaultValue);
 
         if (str_starts_with($value, "B'") && $value[-1] === "'") {
             return $column->phpTypecast(substr($value, 2, -1));

--- a/tests/QueryBuilderTest.php
+++ b/tests/QueryBuilderTest.php
@@ -539,6 +539,39 @@ final class QueryBuilderTest extends CommonQueryBuilderTest
         $this->assertSame($expectedCount, $count);
     }
 
+    public function testArrayOverlapsWithExpressionColumnParams(): void
+    {
+        $db = $this->getSharedConnection();
+        $qb = $db->getQueryBuilder();
+        $params = [];
+
+        $sql = $qb->buildExpression(
+            new ArrayOverlaps(new Expression('array_remove(column, :empty)', [':empty' => null]), [1, 2, 3]),
+            $params,
+        );
+
+        $this->assertSame('array_remove(column, :empty)::int[] && ARRAY[1,2,3]::int[]', $sql);
+        $this->assertSame([':empty' => null], $params);
+    }
+
+    public function testJsonOverlapsWithExpressionColumnParams(): void
+    {
+        $db = $this->getSharedConnection();
+        $qb = $db->getQueryBuilder();
+        $params = [];
+
+        $sql = $qb->buildExpression(
+            new JsonOverlaps(new Expression('jsonb_path_query_array(column, :path)', [':path' => '$[*]']), [1, 2, 3]),
+            $params,
+        );
+
+        $this->assertSame(
+            'ARRAY(SELECT jsonb_array_elements_text(jsonb_path_query_array(column, :path)::jsonb))::int[] && ARRAY[1,2,3]::int[]',
+            $sql,
+        );
+        $this->assertSame([':path' => '$[*]'], $params);
+    }
+
     #[DataProviderExternal(QueryBuilderProvider::class, 'buildColumnDefinition')]
     public function testBuildColumnDefinition(string $expected, Closure|ColumnInterface|string $column): void
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️/❌
| New feature?  | ✔️/❌
| Breaks BC?    | ✔️/❌
| Fixed issues  | 
